### PR TITLE
Ensure folder picker dialog stays on top and cleans up

### DIFF
--- a/src/cross_platform_folder_picker/bases/windows.py
+++ b/src/cross_platform_folder_picker/bases/windows.py
@@ -24,5 +24,9 @@ class WindowsFolderPicker(AbstractFolderPicker):
                 print(f"Warning: Unable to set icon from {icon}. Using default icon.")
 
         root.withdraw()
+        root.attributes("-topmost", True)  # Keep dialog on top
+
         folder_path = filedialog.askdirectory(title=title)
+
+        root.destroy()
         return folder_path


### PR DESCRIPTION
Added 'topmost' attribute to keep the folder picker dialog above other windows and destroy the Tk root after selection to prevent resource leaks.