### PR TITLE
Add GTK folder picker support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,4 @@ build-backend = "hatchling.build"
 
 [project.optional-dependencies]
 qt = ["PySide6"]
+gtk = ["PyGObject"]

--- a/src/cross_platform_folder_picker/__init__.py
+++ b/src/cross_platform_folder_picker/__init__.py
@@ -1,9 +1,18 @@
 import sys
 
 try:
-    import PySide6
+    import PySide6  # type: ignore  # noqa: F401
+
+    HAS_PYSIDE6 = True
 except ImportError:
-    PySide6 = None
+    HAS_PYSIDE6 = False
+try:
+    import gi  # type: ignore  # noqa: F401
+
+    HAS_GI = True
+except ImportError:
+    gi = None
+    HAS_GI = False
 
 
 def open_folder_picker():
@@ -14,10 +23,14 @@ def open_folder_picker():
         str: The path of the selected folder.
     """
 
-    if PySide6 is not None:
-        from .bases.qt import QtFolderPicker
+    if HAS_PYSIDE6:
+        from .bases import QtFolderPicker
 
         picker = QtFolderPicker()
+    elif HAS_GI:
+        from .bases import GtkFolderPicker
+
+        picker = GtkFolderPicker()
     else:
         match sys.platform:
             case "win32":

--- a/src/cross_platform_folder_picker/bases/__init__.py
+++ b/src/cross_platform_folder_picker/bases/__init__.py
@@ -1,3 +1,6 @@
 from .windows import WindowsFolderPicker as WindowsFolderPicker
 from .linux import LinuxFolderPicker as LinuxFolderPicker
 from .macos import MacOSFolderPicker as MacOSFolderPicker
+
+from .qt import QtFolderPicker as QtFolderPicker
+from .gtk import GtkFolderPicker as GtkFolderPicker

--- a/src/cross_platform_folder_picker/bases/gtk.py
+++ b/src/cross_platform_folder_picker/bases/gtk.py
@@ -1,0 +1,84 @@
+from ._abstract import AbstractFolderPicker
+
+
+class GtkFolderPicker(AbstractFolderPicker):
+    def pick_folder(self, title="Select a folder", icon: str | None = None) -> str:
+        try:
+            import gi
+
+            gi.require_version("Gtk", "4.0")
+            from gi.repository import Gtk
+        except (ImportError, ValueError):
+            raise ImportError(
+                "GTK 4 is required for GtkFolderPicker.\n"
+                "Install GTK 4 and PyGObject:\n"
+                "  Linux: sudo apt install libgtk-4-dev gir1.2-gtk-4.0\n"
+                "  pip install PyGObject\n"
+                "  Windows: use MSYS2 and install gtk4, pygobject"
+            )
+
+        # Optional Libadwaita support on Linux
+        use_adw = False
+        try:
+            gi.require_version("Adw", "1")
+            from gi.repository import Adw
+
+            use_adw = True
+        except (ImportError, ValueError):
+            pass  # Libadwaita not available — use plain GTK
+
+        folder_path = ""
+
+        def choose_folder():
+            chooser = Gtk.FileChooserNative.new(
+                title,
+                None,
+                Gtk.FileChooserAction.SELECT_FOLDER,
+                "_Open",
+                "_Cancel",
+            )
+
+            if icon:
+                try:
+                    chooser.set_icon_name(icon)
+                except Exception:
+                    pass  # Ignore icon issues
+
+            response = chooser.run()
+            if response == Gtk.ResponseType.ACCEPT:
+                file = chooser.get_file()
+                return file.get_path() if file else ""
+            return ""
+
+        if use_adw:
+
+            class App(Adw.Application):
+                def __init__(self):
+                    super().__init__(application_id="com.example.folderpicker")
+                    self.result = ""
+
+                def do_activate(self):
+                    Adw.ApplicationWindow(application=self)
+                    self.result = choose_folder()
+                    self.quit()
+
+            app = App()
+            app.run([])
+            folder_path = app.result
+
+        else:
+
+            class App(Gtk.Application):
+                def __init__(self):
+                    super().__init__(application_id="com.example.folderpicker")
+                    self.result = ""
+
+                def do_activate(self):
+                    self.result = choose_folder()
+                    self.quit()
+
+            app = App()
+            app.run([])
+            folder_path = app.result
+
+        return folder_path


### PR DESCRIPTION
Introduces GtkFolderPicker for Linux platforms using GTK 4 and optional Libadwaita. Updates dependency management to include PyGObject as an optional dependency and refactors initialization to support both Qt and GTK folder pickers.